### PR TITLE
Remove unused Chart.js import

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>🎵 BPM Detector</title>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <!-- Chart.js removed: the application draws the waveform manually -->
   <script type="module" defer>
     import { BeatTracker, quickBeatTrack, BeatTrackingUI } from './xa-beat-tracker.js';
 


### PR DESCRIPTION
## Summary
- strip unused Chart.js script tag
- add comment noting manual waveform drawing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684551126fe883258485cc4d5b92222e