### PR TITLE
Add dynamic beat tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <title>🎵 BPM Detector</title>
   <!-- Chart.js removed: the application draws the waveform manually -->
   <script type="module" defer>
-    import { BeatTracker, quickBeatTrack, BeatTrackingUI } from './xa-beat-tracker.js';
+    import { BeatTracker, quickBeatTrack, BeatTrackingUI, dynamicBeatTrack } from './xa-beat-tracker.js';
 
     // DOM elements
     const fileInput = document.getElementById("fileInput");
@@ -231,20 +231,10 @@
           logMessage(`   ⚠️ Moderate (5-15 BPM): ${moderateCount} windows`);
           logMessage(`   ❌ Unstable (>15 BPM): ${unstableCount} windows`);
 
-          logMessage(`🎵 Performing beat tracking (reusing onset envelope)...`);
-          const beatResult = tracker.beatTrack({
-            y,
-            sr,
-            onsetEnvelope: onsetEnvelope,
-            hopLength: 512,
-            startBpm: globalTempo,
-            tightness: 100,
-            trim: true,
-            units: 'time',
-            sparse: true
-          });
-          beatTimes = beatResult.beats;
-          logMessage(`🥁 Beat tracking completed: ${beatTimes.length} beats detected`);
+          logMessage(`🎵 Performing dynamic beat tracking...`);
+          const dynamicResult = dynamicBeatTrack(y, sr, windowSize, hopSize);
+          beatTimes = dynamicResult.beats;
+          logMessage(`🥁 Beat tracking completed: ${beatTimes.length} beats detected (dynamic tempo)`);
 
           logMessage(`🎵 Generating click track for verification...`);
           clickBuffer = ui.generateClickTrack(beatTimes, audioBuffer.duration);

--- a/xa-beat-tracker.js
+++ b/xa-beat-tracker.js
@@ -803,6 +803,45 @@ export function quickBeatTrack(audioData, sampleRate = 44100) {
     return { bpm: 120, beats: [], confidence: 0 }
   }
 }
+
+/**
+ * Beat tracker that adapts to tempo changes using dynamic tempo estimation.
+ * @param {Float32Array} audioData - Audio signal
+ * @param {number} sampleRate - Sample rate
+ * @param {number} windowSize - Window size in seconds for tempo estimation
+ * @param {number} hopSize - Hop size in seconds for tempo estimation
+ * @returns {Object} { tempo: Array, beats: Array }
+ */
+export function dynamicBeatTrack(
+    audioData,
+    sampleRate = 44100,
+    windowSize = 8.0,
+    hopSize = 1.0,
+) {
+  const tracker = new BeatTracker()
+
+  try {
+    const { tempo } = tracker.estimateDynamicTempo(
+        audioData,
+        sampleRate,
+        windowSize,
+        hopSize,
+    )
+
+    const result = tracker.beatTrack({
+      y: audioData,
+      sr: sampleRate,
+      bpm: tempo,
+      units: 'time',
+      sparse: true,
+    })
+
+    return { tempo, beats: result.beats }
+  } catch (error) {
+    console.error('Dynamic beat tracking failed:', error)
+    return { tempo: [], beats: [] }
+  }
+}
 /**
  * Web Audio API integration helpers
  */


### PR DESCRIPTION
## Summary
- support dynamic tempo beat tracking
- use new function during analysis to follow tempo changes

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684622f41b908325a4c2b30e625758e7