### PR TITLE
Fix README port reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install
 npm run dev
 ```
 
-Vite will launch a local server (usually at http://localhost:5173/) where you can interact with the application.
+Vite will launch a local server at http://localhost:3000/ where you can interact with the application.
 
 ## Browser requirements
 


### PR DESCRIPTION
## Summary
- update the dev server URL in README so it matches the configured port

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68462760a2d88325a7bbe887f3dedcf6