### PR TITLE
Update gitignore for node modules and dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 log.txt
 *.log
 logs/
+node_modules/
+dist/


### PR DESCRIPTION
## Summary
- keep Node.js dependencies and Vite build output out of git

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6846276812588325b0c3ae16bbc3debc