### PR TITLE
Update PLP weighting logic

### DIFF
--- a/xa-beat-tracker.js
+++ b/xa-beat-tracker.js
@@ -195,50 +195,50 @@ export class BeatTracker {
       }
     }
 
-    // Find peak values and normalize
-    const ftmag = ftgram.map((frame) =>
-        frame.map((bin) =>
-            Math.log1p(1e6 * Math.sqrt(bin.real * bin.real + bin.imag * bin.imag)),
-        ),
-    )
-
-    // Apply prior if provided
-    if (prior) {
-      for (let i = 0; i < ftmag.length; i++) {
-        for (let j = 0; j < ftmag[i].length; j++) {
-          ftmag[i][j] += prior(tempoFrequencies[j])
-        }
-      }
-    }
-
-    // Keep only values at peak
+    // Apply prior and find peak bin for each frame
     for (let i = 0; i < ftgram.length; i++) {
-      const peakValue = Math.max(...ftmag[i])
+      let maxIdx = -1
+      let maxMag = -Infinity
+
       for (let j = 0; j < ftgram[i].length; j++) {
-        if (ftmag[i][j] < peakValue) {
+        const freq = tempoFrequencies[j]
+
+        // Skip bins outside allowed tempo range
+        if (
+            (tempoMin !== null && freq < tempoMin) ||
+            (tempoMax !== null && freq > tempoMax)
+        ) {
           ftgram[i][j] = { real: 0, imag: 0 }
+          continue
         }
-      }
-    }
 
-    // Normalize to keep phase information
-    for (let i = 0; i < ftgram.length; i++) {
-      const maxMag = Math.max(
-          ...ftgram[i].map((bin) =>
-              Math.sqrt(bin.real * bin.real + bin.imag * bin.imag),
-          ),
-      )
-      for (let j = 0; j < ftgram[i].length; j++) {
-        // Calculate magnitude but don't need to store it
-        Math.sqrt(
+        // Apply prior if provided
+        const weight = prior ? prior(freq) : 1
+        ftgram[i][j].real *= weight
+        ftgram[i][j].imag *= weight
+
+        const mag = Math.sqrt(
             ftgram[i][j].real * ftgram[i][j].real +
             ftgram[i][j].imag * ftgram[i][j].imag,
         )
-        const normFactor = Math.sqrt(1e-10 + maxMag)
-        if (normFactor > 0) {
-          ftgram[i][j].real /= normFactor
-          ftgram[i][j].imag /= normFactor
+
+        if (mag > maxMag) {
+          maxMag = mag
+          maxIdx = j
         }
+      }
+
+      // Zero out all bins except the maximum
+      for (let j = 0; j < ftgram[i].length; j++) {
+        if (j !== maxIdx) {
+          ftgram[i][j] = { real: 0, imag: 0 }
+        }
+      }
+
+      // Normalize the remaining bin to unit magnitude
+      if (maxIdx >= 0 && maxMag > 0) {
+        ftgram[i][maxIdx].real /= maxMag
+        ftgram[i][maxIdx].imag /= maxMag
       }
     }
 


### PR DESCRIPTION
## Summary
- update `plp()` to keep only the strongest tempo bin with phase intact
- apply prior multiplicatively and normalize frames

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846274152208325bd654a801bcaa010