### PR TITLE
Improve normalization for large arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node tests/normalize.test.js"
   },
   "devDependencies": {
     "vite": "^5.0.0"

--- a/tests/normalize.test.js
+++ b/tests/normalize.test.js
@@ -1,0 +1,25 @@
+import assert from 'assert';
+import { BeatTracker } from '../xa-beat-tracker.js';
+
+const normalize = BeatTracker.prototype._normalize;
+
+function testSmallArray() {
+  const arr = [0, 2, 4];
+  const result = normalize(arr);
+  assert.deepStrictEqual(result, [0, 0.5, 1]);
+}
+
+function testLargeArray() {
+  const large = new Float32Array(100000);
+  for (let i = 0; i < large.length; i++) {
+    large[i] = i * 2;
+  }
+  const result = normalize(large);
+  assert.strictEqual(result[0], 0);
+  assert.strictEqual(result[result.length - 1], 1);
+}
+
+testSmallArray();
+testLargeArray();
+
+console.log('All tests passed');

--- a/xa-beat-tracker.js
+++ b/xa-beat-tracker.js
@@ -213,7 +213,10 @@ export class BeatTracker {
 
     // Keep only values at peak
     for (let i = 0; i < ftgram.length; i++) {
-      const peakValue = Math.max(...ftmag[i])
+      let peakValue = -Infinity
+      for (let k = 0; k < ftmag[i].length; k++) {
+        if (ftmag[i][k] > peakValue) peakValue = ftmag[i][k]
+      }
       for (let j = 0; j < ftgram[i].length; j++) {
         if (ftmag[i][j] < peakValue) {
           ftgram[i][j] = { real: 0, imag: 0 }
@@ -223,11 +226,14 @@ export class BeatTracker {
 
     // Normalize to keep phase information
     for (let i = 0; i < ftgram.length; i++) {
-      const maxMag = Math.max(
-          ...ftgram[i].map((bin) =>
-              Math.sqrt(bin.real * bin.real + bin.imag * bin.imag),
-          ),
-      )
+      let maxMag = -Infinity
+      for (let j = 0; j < ftgram[i].length; j++) {
+        const mag = Math.sqrt(
+            ftgram[i][j].real * ftgram[i][j].real +
+            ftgram[i][j].imag * ftgram[i][j].imag,
+        )
+        if (mag > maxMag) maxMag = mag
+      }
       for (let j = 0; j < ftgram[i].length; j++) {
         // Calculate magnitude but don't need to store it
         Math.sqrt(
@@ -508,7 +514,11 @@ export class BeatTracker {
     const cumScore = new Float32Array(N)
 
     // Initialize
-    const scoreThresh = 0.01 * Math.max(...localScore)
+    let maxScore = -Infinity
+    for (let i = 0; i < localScore.length; i++) {
+      if (localScore[i] > maxScore) maxScore = localScore[i]
+    }
+    const scoreThresh = 0.01 * maxScore
     backlink[0] = -1
     cumScore[0] = localScore[0]
 
@@ -654,7 +664,10 @@ export class BeatTracker {
 
   _findPeaksWithProminence(signal, minProminence = 0.1) {
     const peaks = []
-    const maxVal = Math.max(...signal)
+    let maxVal = -Infinity
+    for (let i = 0; i < signal.length; i++) {
+      if (signal[i] > maxVal) maxVal = signal[i]
+    }
 
     for (let i = 1; i < signal.length - 1; i++) {
       if (signal[i] > signal[i - 1] && signal[i] > signal[i + 1]) {
@@ -762,11 +775,16 @@ export class BeatTracker {
   }
 
   _normalize(x) {
-    const max = Math.max(...x)
-    const min = Math.min(...x)
+    let max = -Infinity
+    let min = Infinity
+    for (let i = 0; i < x.length; i++) {
+      const v = x[i]
+      if (v > max) max = v
+      if (v < min) min = v
+    }
     const range = max - min
 
-    if (range === 0) return x
+    if (range === 0) return x.map(() => 0)
 
     return x.map((v) => (v - min) / range)
   }


### PR DESCRIPTION
## Summary
- avoid spreading arrays when computing max and min
- normalize constant arrays to 0
- add basic unit tests covering small and large inputs
- expose npm `test` script for running the new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68462751fe008325846e61816512d4cd