### PR TITLE
Hide PLP button by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -1376,7 +1376,7 @@
       <button id="quickAnalyzeBtn" disabled>⚡ Quick Analyze</button>
       <button id="beatTrackBtn" disabled>beat_track()</button>
       <button id="tempoBtn" disabled>tempo()</button>
-      <button id="plpBtn" disabled>PLP Analyze</button>
+      <button id="plpBtn" disabled hidden>PLP Analyze</button>
       <button id="clickBtn">🔇 Click Track</button>
       <button id="collapseAllBtn">⏬ Collapse All</button>
       <button id="expandAllBtn">⏫ Expand All</button>


### PR DESCRIPTION
## Summary
- hide the PLP button by default so it doesn't appear on load

## Testing
- `npm test` *(fails: Unexpected token in xa-beat-tracker.js)*

------
https://chatgpt.com/codex/tasks/task_e_68462c6d2b148325a7d2ff44adab6515