### PR TITLE
Convert normalize test to Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node tests/normalize.test.js"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "devDependencies": {
     "vite": "^5.0.0",

--- a/tests/normalize.test.js
+++ b/tests/normalize.test.js
@@ -1,25 +1,19 @@
-import assert from 'assert';
 import { BeatTracker } from '../xa-beat-tracker.js';
 
 const normalize = BeatTracker.prototype._normalize;
 
-function testSmallArray() {
+test('normalize handles small arrays', () => {
   const arr = [0, 2, 4];
   const result = normalize(arr);
-  assert.deepStrictEqual(result, [0, 0.5, 1]);
-}
+  expect(result).toEqual([0, 0.5, 1]);
+});
 
-function testLargeArray() {
+test('normalize handles large arrays', () => {
   const large = new Float32Array(100000);
   for (let i = 0; i < large.length; i++) {
     large[i] = i * 2;
   }
   const result = normalize(large);
-  assert.strictEqual(result[0], 0);
-  assert.strictEqual(result[result.length - 1], 1);
-}
-
-testSmallArray();
-testLargeArray();
-
-console.log('All tests passed');
+  expect(result[0]).toBe(0);
+  expect(result[result.length - 1]).toBe(1);
+});


### PR DESCRIPTION
## Summary
- use Jest `test` and `expect` in `normalize` tests
- run tests through Jest by default

## Testing
- `npm test` *(fails: Cannot find module '/workspace/lb/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68462d4ae248832592cd481e3d1e63cb