### PR TITLE
Handle quickBeatTrack errors without assuming 120 BPM

### DIFF
--- a/xa-beat-tracker.js
+++ b/xa-beat-tracker.js
@@ -841,7 +841,7 @@ export function quickBeatTrack(audioData, sampleRate = 44100) {
     }
   } catch (error) {
     console.error('Beat tracking failed:', error)
-    return { bpm: 120, beats: [], confidence: 0 }
+    return { bpm: 0, beats: [], confidence: 0 }
   }
 }
 


### PR DESCRIPTION
## Summary
- return 0 BPM when `quickBeatTrack` fails instead of a misleading 120 BPM

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684631b973788325b775f38a42b92183