### PR TITLE
Adjust quickBeatTrack fallback

### DIFF
--- a/__tests__/beat-tracker.test.js
+++ b/__tests__/beat-tracker.test.js
@@ -55,3 +55,10 @@ test('quickBeatTrack uses detected tempo instead of fallback', () => {
   expect(result.beats.length).toBe(8);
   expect(result.confidence).toBeGreaterThan(0);
 });
+
+test('quickBeatTrack returns 0 BPM when beatTrack fails', () => {
+  const result = quickBeatTrack(null, 44100);
+  expect(result.bpm).toBe(0);
+  expect(result.beats).toEqual([]);
+  expect(result.confidence).toBe(0);
+});

--- a/xa-beat-tracker.js
+++ b/xa-beat-tracker.js
@@ -841,7 +841,7 @@ export function quickBeatTrack(audioData, sampleRate = 44100) {
     }
   } catch (error) {
     console.error('Beat tracking failed:', error)
-    return { bpm: 120, beats: [], confidence: 0 }
+    return { bpm: 0, beats: [], confidence: 0 }
   }
 }
 


### PR DESCRIPTION
## Summary
- return zero BPM when `quickBeatTrack` fails
- cover failure case with a new unit test

## Testing
- `npm test` *(fails: cannot find module `jest`)*

------
https://chatgpt.com/codex/tasks/task_e_684631335dac8325bf5dd8bf0ba20770