### PR TITLE
Fix click track context mismatch

### DIFF
--- a/main.js
+++ b/main.js
@@ -73,6 +73,8 @@
         clearLog();
         logMessage("Loading audio file...");
         audioContext = new AudioContext();
+        ui.audioContext = audioContext; // ensure click track uses same context
+        ui.tracker.audioContext = audioContext;
         const arrayBuffer = await file.arrayBuffer();
         audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
         bpmDisplay.textContent = "BPM: --";


### PR DESCRIPTION
## Summary
- ensure generated click track uses the same `AudioContext` as playback

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684631908f8c832588024cf85c1225e7