### PR TITLE
Reveal PLP button when advanced mode enabled

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,6 +19,20 @@
     const logToggle = document.getElementById("logToggle");
     const waveformToggle = document.getElementById("waveformToggle");
 
+    const showPlp = () => {
+      plpBtn.removeAttribute('hidden');
+    };
+
+    if (new URLSearchParams(window.location.search).get('advanced')) {
+      showPlp();
+    }
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Alt') {
+        showPlp();
+      }
+    });
+
     // State variables
     let audioContext, sourceNode, audioBuffer, beatTimes, startTime;
     let animationFrame, bpmInterval;


### PR DESCRIPTION
## Summary
- show PLP analyze button when the `advanced` query parameter is present
- allow Alt key to reveal the PLP button

## Testing
- `npm test` *(fails: Cannot find module '/workspace/lb/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_684635da57e48325ba861f61005011b8