### PR TITLE
Remove unused wasPlaying variable

### DIFF
--- a/main.js
+++ b/main.js
@@ -465,7 +465,6 @@
       if (!sourceNode || !audioContext) return;
       
       const currentTime = audioContext.currentTime - startTime;
-      const wasPlaying = true;
       
       // Stop current playback
       if (sourceNode) sourceNode.stop();


### PR DESCRIPTION
## Summary
- remove the unused `wasPlaying` constant in `restartPlaybackWithClick`

## Testing
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_684635e38f58832584a050758447699a