### PR TITLE
Add PLP test with FFT fix

### DIFF
--- a/__tests__/plp.test.js
+++ b/__tests__/plp.test.js
@@ -1,0 +1,36 @@
+import { BeatTracker } from '../xa-beat-tracker.js';
+
+function createOnsetEnvelope(bpm, sr, hop, beats) {
+  const framesPerBeat = Math.round((sr / hop) * (60 / bpm));
+  const length = framesPerBeat * beats;
+  const onset = new Float32Array(length).fill(0);
+
+  for (let i = 0; i < length; i += framesPerBeat) {
+    for (let j = 0; j < 5; j++) {
+      if (i + j < length) onset[i + j] = 1 - j * 0.2;
+    }
+  }
+
+  return { onset, framesPerBeat };
+}
+
+test('plp pulse peaks align with beat frames', () => {
+  const tracker = new BeatTracker();
+  const sr = 22050;
+  const hop = 512;
+  const beats = 20;
+  const { onset, framesPerBeat } = createOnsetEnvelope(120, sr, hop, beats);
+  const pulse = tracker.plp({ onsetEnvelope: onset, sr, hopLength: hop });
+
+  const maxima = tracker._localMax(pulse);
+  const peakFrames = [];
+  for (let i = 0; i < maxima.length; i++) {
+    if (maxima[i]) peakFrames.push(i);
+  }
+
+  for (let b = 0; b < 8; b++) {
+    const expected = b * framesPerBeat;
+    const found = peakFrames.find((p) => Math.abs(p - expected) <= 2);
+    expect(found).toBeDefined();
+  }
+});

--- a/xa-beat-tracker.js
+++ b/xa-beat-tracker.js
@@ -1,7 +1,7 @@
 
 // Lightweight FFT implementation integrated directly for browser use
 function fft(signal) {
-  const complexSignal = signal.map((v) => ({ real: v, imag: 0 }))
+  const complexSignal = Array.from(signal, (v) => ({ real: v, imag: 0 }))
   return _fftComplex(complexSignal)
 }
 
@@ -243,6 +243,11 @@ export class BeatTracker {
         sr,
         hopLength,
         winLength,
+    )
+
+    // Pre-compute magnitude of each tempogram bin
+    const ftmag = ftgram.map((frame) =>
+        frame.map((c) => Math.sqrt(c.real * c.real + c.imag * c.imag)),
     )
 
     // Apply tempo constraints


### PR DESCRIPTION
## Summary
- add unit test for `plp` peak positions
- fix `fft` to handle typed arrays
- pre-compute tempogram magnitudes in `plp`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: cannot find module jest)*

------
https://chatgpt.com/codex/tasks/task_e_684635e50e848325bee11c07440f6c2d