### PR TITLE
Refine PLP prior weighting

### DIFF
--- a/xa-beat-tracker.js
+++ b/xa-beat-tracker.js
@@ -237,11 +237,10 @@ export class BeatTracker {
 
     // Compute Fourier tempogram
     const ftgram = this.fourierTempogram(onset, sr, hopLength, winLength)
-    // Magnitudes of each STFT bin
+
+    // Pre-compute magnitudes for each bin
     const ftmag = ftgram.map((frame) =>
-      frame.map((bin) =>
-        Math.sqrt(bin.real * bin.real + bin.imag * bin.imag)
-      ),
+      frame.map((bin) => Math.sqrt(bin.real * bin.real + bin.imag * bin.imag)),
     )
 
     // Get tempo frequencies
@@ -273,11 +272,11 @@ export class BeatTracker {
 
       for (let j = 0; j < ftgram[i].length; j++) {
         const mag = ftmag[i][j]
-        const weight = prior ? prior(tempoFrequencies[j]) : 1
-        const weighted = mag * weight
+        const priorWeight = prior ? prior(tempoFrequencies[j]) : 1
+        const weightedMag = mag * priorWeight
 
-        if (weighted > maxWeight) {
-          maxWeight = weighted
+        if (weightedMag > maxWeight) {
+          maxWeight = weightedMag
           maxIdx = j
           maxMag = mag
         }


### PR DESCRIPTION
## Summary
- refine PLP tempogram bin weighting logic

## Testing
- `npm test` *(fails: Cannot find module '/workspace/lb/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_684636eb9df4832584499f5ea92c58ec