### PR TITLE
Reset file input after load

### DIFF
--- a/main.js
+++ b/main.js
@@ -102,6 +102,8 @@
         plpBtn.disabled = false;
         collapseAllBtn.disabled = false;
         expandAllBtn.disabled = false;
+        // reset so selecting the same file again fires change
+        fileInput.value = "";
       } catch (error) {
         console.error("File loading error:", error);
         bpmDisplay.textContent = "BPM: Error";


### PR DESCRIPTION
## Summary
- reset file input after loading so selecting the same file again triggers the `change` handler

## Testing
- `npm test` *(fails: Cannot find module '/workspace/lb/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68463b92213c8325b1db36c8e4cbe91e