### PR TITLE
Add setup script for dependency installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "pretest": "./setup.sh"
   },
   "devDependencies": {
     "vite": "^5.0.0",

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+npm install


### PR DESCRIPTION
## Summary
- add `setup.sh` to install npm dependencies
- run `setup.sh` automatically before tests via `pretest` in `package.json`

## Testing
- `npm test` *(fails: 403 Forbidden while trying to fetch npm packages)*

------
https://chatgpt.com/codex/tasks/task_e_68463e49b26c8325a4cc2dab83b5f78f