### PR TITLE
Fix waveform minmax computation

### DIFF
--- a/main.js
+++ b/main.js
@@ -1142,8 +1142,13 @@
       const height = canvas.height;
       ctx.clearRect(0, 0, width, height);
       const channelData = audioBuffer.getChannelData(0);
-      const minValue = Math.min(...channelData);
-      const maxValue = Math.max(...channelData);
+      let minValue = Infinity;
+      let maxValue = -Infinity;
+      for (let i = 0; i < channelData.length; i++) {
+        const v = channelData[i];
+        if (v < minValue) minValue = v;
+        if (v > maxValue) maxValue = v;
+      }
       const normalizedData = channelData.map(value => (value - minValue) / (maxValue - minValue));
       ctx.beginPath();
       ctx.moveTo(0, height / 2);


### PR DESCRIPTION
## Summary
- improve waveform min/max calculation to avoid spreading large arrays

## Testing
- `npm test` *(fails: 403 Forbidden fetching jest)*

------
https://chatgpt.com/codex/tasks/task_e_68463fe724108325b5b4c630207ea717