### PR TITLE
Add BPM range test

### DIFF
--- a/__tests__/beat-tracker.test.js
+++ b/__tests__/beat-tracker.test.js
@@ -62,3 +62,22 @@ test('quickBeatTrack returns 0 BPM when beatTrack fails', () => {
   expect(result.beats).toEqual([]);
   expect(result.confidence).toBe(0);
 });
+
+test('beatTrack respects BPM range constraints', () => {
+  const tracker = new BeatTracker();
+  const sr = 22050;
+  const hop = 512;
+  const beats = 10;
+  const { onset } = createOnsetEnvelope(96, sr, hop, beats);
+  const result = tracker.beatTrack({
+    onsetEnvelope: onset,
+    sr,
+    hopLength: hop,
+    minBpm: 70,
+    maxBpm: 180,
+    units: 'frames',
+    sparse: true,
+  });
+  expect(result.beats.length).toBe(beats);
+  expect(Math.round(result.tempo)).toBeCloseTo(96);
+});


### PR DESCRIPTION
## Summary
- extend beat-tracker tests with BPM range scenario

## Testing
- `npm test` *(fails: 403 Forbidden when fetching Jest)*

------
https://chatgpt.com/codex/tasks/task_e_6846412d559083259789ded0ea2a9ece