### PR TITLE
Add beatTrack tempo constraint test

### DIFF
--- a/__tests__/beat-tracker.test.js
+++ b/__tests__/beat-tracker.test.js
@@ -62,3 +62,22 @@ test('quickBeatTrack returns 0 BPM when beatTrack fails', () => {
   expect(result.beats).toEqual([]);
   expect(result.confidence).toBe(0);
 });
+
+test('beatTrack respects tempo constraints', () => {
+  const tracker = new BeatTracker();
+  const sr = 22050;
+  const hop = 512;
+  const beats = 6;
+  const { onset } = createOnsetEnvelope(96, sr, hop, beats);
+  const result = tracker.beatTrack({
+    onsetEnvelope: onset,
+    sr,
+    hopLength: hop,
+    units: 'frames',
+    sparse: true,
+    minBpm: 70,
+    maxBpm: 180,
+  });
+  expect(result.beats.length).toBe(beats);
+  expect(Math.round(result.tempo)).toBe(96);
+});


### PR DESCRIPTION
## Summary
- add a new unit test verifying beatTrack operates correctly with min/max BPM constraints

## Testing
- `npm test` *(fails: 403 Forbidden during npm install)*

------
https://chatgpt.com/codex/tasks/task_e_6846445f55ec8325811fe3e39fe6a7f8