### PR TITLE
Add web worker BPM analyzer

### DIFF
--- a/analyzerWorker.js
+++ b/analyzerWorker.js
@@ -1,0 +1,19 @@
+import { quickBeatTrack } from './xa-beat-tracker.js';
+
+self.onmessage = async (e) => {
+  const { arrayBuffer } = e.data || {};
+  if (!arrayBuffer) {
+    self.postMessage({ error: 'No ArrayBuffer provided' });
+    return;
+  }
+
+  try {
+    const ctx = new OfflineAudioContext(1, 1, 44100);
+    const buffer = await ctx.decodeAudioData(arrayBuffer);
+    const channelData = buffer.getChannelData(0);
+    const { bpm, beats } = quickBeatTrack(channelData, buffer.sampleRate);
+    self.postMessage({ bpm, beats });
+  } catch (err) {
+    self.postMessage({ error: err.message });
+  }
+};

--- a/audio.js
+++ b/audio.js
@@ -1,0 +1,53 @@
+let worker;
+
+function startWorker() {
+  if (worker) return;
+  worker = new Worker('./analyzerWorker.js', { type: 'module' });
+
+  worker.addEventListener('message', (e) => {
+    const bpmDisplay = document.getElementById('bpm');
+    if (!bpmDisplay) return;
+    const { bpm, error } = e.data;
+    if (error) {
+      console.error('Worker error:', error);
+      bpmDisplay.textContent = 'BPM: Error';
+    } else if (typeof bpm === 'number') {
+      bpmDisplay.textContent = `BPM: ${bpm.toFixed(1)}`;
+    }
+  });
+}
+
+function stopWorker() {
+  if (worker) {
+    worker.terminate();
+    worker = null;
+  }
+}
+
+async function handleFile(e) {
+  const file = e.target.files[0];
+  if (!file || !worker) return;
+  try {
+    const buffer = await file.arrayBuffer();
+    worker.postMessage({ arrayBuffer: buffer }, [buffer]);
+  } catch (err) {
+    console.error('Failed to send file to worker:', err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  startWorker();
+  const fileInput = document.getElementById('fileInput');
+  if (fileInput) fileInput.addEventListener('change', handleFile);
+
+  const stopBtn = document.getElementById('stopBtn');
+  if (stopBtn) stopBtn.addEventListener('click', stopWorker);
+
+  const resetBtn = document.getElementById('resetBtn');
+  if (resetBtn) resetBtn.addEventListener('click', () => {
+    stopWorker();
+    startWorker();
+  });
+});
+
+export { startWorker, stopWorker };


### PR DESCRIPTION
## Summary
- add `analyzerWorker.js` for BPM analysis using `OfflineAudioContext`
- add `audio.js` to send file buffers to the worker and terminate it on stop/reset

## Testing
- `npm test` *(fails: 403 Forbidden when trying to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684646c1157883258e56d8a3959a01ab