### PR TITLE
Add CI workflow and worker tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/__tests__/bpm-edge.test.js
+++ b/__tests__/bpm-edge.test.js
@@ -1,0 +1,35 @@
+import { BeatTracker } from '../xa-beat-tracker.js';
+
+function createOnsetEnvelope() {
+  return new Float32Array([1, 0, 0, 0, 1, 0, 0, 0]);
+}
+
+test('beatTrack throws for non-positive BPM', () => {
+  const tracker = new BeatTracker();
+  const onset = createOnsetEnvelope();
+  expect(() => {
+    tracker.beatTrack({
+      onsetEnvelope: onset,
+      sr: 22050,
+      hopLength: 512,
+      bpm: -120,
+      units: 'frames',
+    });
+  }).toThrow('BPM must be strictly positive');
+});
+
+test('plp rejects invalid tempo range', () => {
+  const tracker = new BeatTracker();
+  const onset = createOnsetEnvelope();
+  expect(() => {
+    tracker.plp({ onsetEnvelope: onset, tempoMin: 120, tempoMax: 100 });
+  }).toThrow('tempoMax=100 must be larger than tempoMin=120');
+});
+
+test('tempoEstimation clamps to range', () => {
+  const tracker = new BeatTracker();
+  const onset = createOnsetEnvelope();
+  const bpm = tracker.tempoEstimation(onset, 22050, 512, 200, 80, 120);
+  expect(bpm).toBeLessThanOrEqual(120);
+  expect(bpm).toBeGreaterThanOrEqual(80);
+});

--- a/__tests__/worker-roundtrip.test.js
+++ b/__tests__/worker-roundtrip.test.js
@@ -1,0 +1,26 @@
+import { Worker } from 'worker_threads';
+import { fileURLToPath } from 'url';
+
+function createOnsetEnvelope(bpm, sr, hop, beats) {
+  const framesPerBeat = Math.round((sr / hop) * (60 / bpm));
+  const length = framesPerBeat * beats;
+  const onset = new Float32Array(length).fill(0);
+  for (let i = 0; i < length; i += framesPerBeat) {
+    onset[i] = 1;
+  }
+  return { onset };
+}
+
+test('worker returns beat tracking result', async () => {
+  const sr = 22050;
+  const hop = 512;
+  const { onset } = createOnsetEnvelope(120, sr, hop, 8);
+  const worker = new Worker(new URL('../bpm-worker.js', import.meta.url), { type: 'module' });
+  const result = await new Promise((resolve) => {
+    worker.once('message', (msg) => resolve(msg));
+    worker.postMessage({ onset, sr });
+  });
+  worker.terminate();
+  expect(Math.round(result.bpm)).toBe(120);
+  expect(result.beats.length).toBe(8);
+});

--- a/bpm-worker.js
+++ b/bpm-worker.js
@@ -1,0 +1,10 @@
+import { parentPort } from 'worker_threads';
+import { BeatTracker, quickBeatTrack } from './xa-beat-tracker.js';
+
+parentPort.on('message', ({ onset, sr }) => {
+  const orig = BeatTracker.prototype.onsetStrength;
+  BeatTracker.prototype.onsetStrength = function(y) { return y; };
+  const result = quickBeatTrack(onset, sr);
+  BeatTracker.prototype.onsetStrength = orig;
+  parentPort.postMessage(result);
+});


### PR DESCRIPTION
## Summary
- add CI workflow caching npm modules and running tests
- test worker round-trip through new bpm-worker.js
- cover BPM calculation edge cases

## Testing
- `npm test` *(fails: 403 Forbidden downloading jest)*

------
https://chatgpt.com/codex/tasks/task_e_684646ce7890832580be8594820e508b