### PR TITLE
Configure GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ log.txt
 *.log
 logs/
 node_modules/
-dist/
+# Build output is committed to gh-pages

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ npm run build        # create the production build in dist/
 npm run preview      # serve the built files locally
 ```
 
+## Deploying to GitHub Pages
+
+Build the site and publish the output to the `gh-pages` branch:
+
+```sh
+npm run deploy
+```
+
+After pushing, configure the repository to serve Pages from that branch.
+
 ## Browser requirements
 
 A modern browser with Web Audio API support (e.g. current versions of Chrome, Edge, or Firefox) is required for beat tracking.

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "deploy": "npm run build && npx gh-pages -d dist",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "pretest": "./setup.sh"
   },
   "devDependencies": {
     "vite": "^5.0.0",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "gh-pages": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- remove dist from .gitignore so Pages can track build files
- add deploy script using `gh-pages`
- document GitHub Pages deployment

## Testing
- `npm test` *(fails: 403 Forbidden when installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684646d2449883259f0117656879af3d