### PR TITLE
Add waveform render after file load

### DIFF
--- a/main.js
+++ b/main.js
@@ -91,6 +91,7 @@
         ui.tracker.audioContext = audioContext;
         const arrayBuffer = await file.arrayBuffer();
         audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+        drawWaveform();
         bpmDisplay.textContent = "BPM: --";
         logMessage("✅ Audio file loaded successfully");
         logMessage(`Duration: ${audioBuffer.duration.toFixed(1)}s, Sample Rate: ${audioBuffer.sampleRate}Hz`);


### PR DESCRIPTION
## Summary
- draw waveform once audio is decoded in the file input handler

## Testing
- `npm test` *(fails: 403 Forbidden while installing jest)*

------
https://chatgpt.com/codex/tasks/task_e_684646e68e508325a2ca6fc3bf1ce7af