### PR TITLE
Add result banner helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,6 +203,7 @@
   <div class="container">
     <h1>🎵 BPM Detector</h1>
     <div id="bpm">BPM: --</div>
+    <div id="resultBanner" class="hidden"><h2><span id="bpmValue"></span> BPM</h2><small id="confValue"></small></div>
     <progress id="analysisProgress" value="0" max="100" hidden aria-valuenow="0"></progress>
 
     <input type="file" id="fileInput" accept="audio/*" />

--- a/main.js
+++ b/main.js
@@ -128,6 +128,16 @@ const ui = new BeatTrackingUI();
 
     }
 
+    function showResultBanner(bpm, confidence) {
+      bpmValue.textContent = bpm.toFixed ? bpm.toFixed(1) : bpm;
+      if (confidence !== undefined) {
+        confValue.textContent = `${(confidence * 100).toFixed(1)}% confidence`;
+      } else {
+        confValue.textContent = '';
+      }
+      resultBanner.style.display = 'block';
+    }
+
     // Catch unexpected promise rejections to keep the UI responsive
     window.addEventListener('unhandledrejection', (event) => {
       console.error('Unhandled promise rejection:', event.reason);
@@ -377,6 +387,7 @@ const ui = new BeatTrackingUI();
           if (tempogram.peakTempos.length > 1) {
             logMessage(`   🎼 Multiple tempo candidates detected - possible tempo changes or polyrhythm`);
           }
+          showResultBanner(globalTempo, confidence);
         } else {
           throw new Error(result.error);
 


### PR DESCRIPTION
## Summary
- add a hidden result banner after the BPM display
- expose `showResultBanner` in main.js to populate banner and reveal it
- display the banner after full analysis

## Testing
- `npm test` *(fails: 403 Forbidden for package download)*

------
https://chatgpt.com/codex/tasks/task_e_68464ce4ff24832591537c04baeb6128