### PR TITLE
Remove unused import in worker roundtrip test

### DIFF
--- a/__tests__/worker-roundtrip.test.js
+++ b/__tests__/worker-roundtrip.test.js
@@ -1,5 +1,4 @@
 import { Worker } from 'worker_threads';
-import { fileURLToPath } from 'url';
 
 function createOnsetEnvelope(bpm, sr, hop, beats) {
   const framesPerBeat = Math.round((sr / hop) * (60 / bpm));


### PR DESCRIPTION
## Summary
- clean up `worker-roundtrip.test.js` by removing an unused `fileURLToPath` import

## Testing
- `npm test` *(fails: 403 Forbidden when attempting to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_68464d7a8ca8832588683b4410e810c1